### PR TITLE
TEST

### DIFF
--- a/e2e/express.e2e-spec.ts
+++ b/e2e/express.e2e-spec.ts
@@ -163,6 +163,95 @@ describe('Express Swagger', () => {
     });
   });
 
+  describe('disabled Swagger Documents(JSON, YAML) but served Swagger UI', () => {
+    const SWAGGER_RELATIVE_URL = '/apidoc';
+
+    beforeEach(async () => {
+      const swaggerDocument = SwaggerModule.createDocument(
+        app,
+        builder.build()
+      );
+      SwaggerModule.setup(SWAGGER_RELATIVE_URL, app, swaggerDocument, {
+        documentsEnabled: false
+      });
+
+      await app.init();
+    });
+
+    afterEach(async () => {
+      await app.close();
+    });
+
+    it('should not serve the JSON definition file', async () => {
+      const response = await request(app.getHttpServer()).get(
+        `${SWAGGER_RELATIVE_URL}-json`
+      );
+
+      expect(response.status).toEqual(404);
+    });
+
+    it('should not serve the YAML definition file', async () => {
+      const response = await request(app.getHttpServer()).get(
+        `${SWAGGER_RELATIVE_URL}-yaml`
+      );
+
+      expect(response.status).toEqual(404);
+    });
+
+    it.each([SWAGGER_RELATIVE_URL, `${SWAGGER_RELATIVE_URL}/`])(
+      'should serve Swagger UI at "%s"',
+      async (url) => {
+        const response = await request(app.getHttpServer()).get(url);
+        expect(response.status).toEqual(200);
+      }
+    );
+  });
+
+  describe('disabled Both Swagger UI AND Swagger Documents(JSON, YAML)', () => {
+    const SWAGGER_RELATIVE_URL = '/apidoc';
+
+    beforeEach(async () => {
+      const swaggerDocument = SwaggerModule.createDocument(
+        app,
+        builder.build()
+      );
+      SwaggerModule.setup(SWAGGER_RELATIVE_URL, app, swaggerDocument, {
+        swaggerUiEnabled: false,
+        documentsEnabled: false
+      });
+
+      await app.init();
+    });
+
+    afterEach(async () => {
+      await app.close();
+    });
+
+    it('should not serve the JSON definition file', async () => {
+      const response = await request(app.getHttpServer()).get(
+        `${SWAGGER_RELATIVE_URL}-json`
+      );
+
+      expect(response.status).toEqual(404);
+    });
+
+    it('should not serve the YAML definition file', async () => {
+      const response = await request(app.getHttpServer()).get(
+        `${SWAGGER_RELATIVE_URL}-yaml`
+      );
+
+      expect(response.status).toEqual(404);
+    });
+
+    it.each([SWAGGER_RELATIVE_URL, `${SWAGGER_RELATIVE_URL}/`])(
+      'should not serve Swagger UI at "%s"',
+      async (url) => {
+        const response = await request(app.getHttpServer()).get(url);
+        expect(response.status).toEqual(404);
+      }
+    );
+  });
+
   describe('custom documents endpoints', () => {
     const JSON_CUSTOM_URL = '/apidoc-json';
     const YAML_CUSTOM_URL = '/apidoc-yaml';

--- a/lib/interfaces/swagger-custom-options.interface.ts
+++ b/lib/interfaces/swagger-custom-options.interface.ts
@@ -1,5 +1,5 @@
-import { SwaggerUiOptions } from './swagger-ui-options.interface';
 import { OpenAPIObject } from './open-api-spec.interface';
+import { SwaggerUiOptions } from './swagger-ui-options.interface';
 
 export interface SwaggerCustomOptions {
   /**
@@ -10,11 +10,19 @@ export interface SwaggerCustomOptions {
   useGlobalPrefix?: boolean;
 
   /**
-   * If `false`, only API definitions (JSON and YAML) will be served (on `/{path}-json` and `/{path}-yaml`).
-   * This is particularly useful if you are already hosting a Swagger UI somewhere else and just want to serve API definitions.
+   * If `false`, the Swagger UI will not be served. Only API definitions (JSON and YAML)
+   * will be accessible (on `/{path}-json` and `/{path}-yaml`).
+   * To fully disable both the Swagger UI and API definitions, use `documentsEnabled: false`.
    * Default: `true`.
    */
   swaggerUiEnabled?: boolean;
+
+  /**
+   * If `false`, both the Swagger UI and API definitions (JSON and YAML) will be disabled.
+   * Use this option when you want to completely hide all Swagger-related endpoints.
+   * Default: `true`.
+   */
+  documentsEnabled?: boolean;
 
   /**
    * Url point the API definition to load in Swagger UI.
@@ -103,5 +111,4 @@ export interface SwaggerCustomOptions {
    * @deprecated This property has no effect.
    */
   urls?: Record<'url' | 'name', string>[];
-
 }

--- a/lib/swagger-module.ts
+++ b/lib/swagger-module.ts
@@ -86,6 +86,7 @@ export class SwaggerModule {
     documentOrFactory: OpenAPIObject | (() => OpenAPIObject),
     options: {
       swaggerUiEnabled: boolean;
+      documentsEnabled: boolean;
       jsonDocumentUrl: string;
       yamlDocumentUrl: string;
       swaggerOptions: SwaggerCustomOptions;
@@ -112,7 +113,11 @@ export class SwaggerModule {
         options.swaggerOptions
       );
     }
-    this.serveDefinitions(httpAdapter, getBuiltDocument, options);
+
+    // Skip registering JSON/YAML endpoints if documentsEnabled is false
+    if (options.documentsEnabled) {
+      this.serveDefinitions(httpAdapter, getBuiltDocument, options);
+    }
   }
 
   protected static serveSwaggerUi(
@@ -283,6 +288,7 @@ export class SwaggerModule {
       : `${finalPath}-yaml`;
 
     const swaggerUiEnabled = options?.swaggerUiEnabled ?? true;
+    const documentsEnabled = options?.documentsEnabled ?? true;
 
     const httpAdapter = app.getHttpAdapter();
 
@@ -293,6 +299,7 @@ export class SwaggerModule {
       documentOrFactory,
       {
         swaggerUiEnabled,
+        documentsEnabled,
         jsonDocumentUrl: finalJSONDocumentPath,
         yamlDocumentUrl: finalYAMLDocumentPath,
         swaggerOptions: options || {}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently, the Swagger module always serves both Swagger UI and JSON/YAML API definitions. There is no way to selectively disable one or the other.

Issue Number: #3157 


## What is the new behavior?
This PR introduces two new options to provide greater control over Swagger endpoints:

swaggerUiEnabled: If false, the Swagger UI will not be served.
documentsEnabled: If false, JSON and YAML API definitions will not be served.

Developers can now:
1. Disable the Swagger UI but retain JSON/YAML definitions.
2. Disable JSON/YAML definitions but retain the Swagger UI.
3. Completely disable all Swagger-related endpoints.

These changes enhance the flexibility and security of Swagger integration, enabling better alignment with deployment needs.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information
